### PR TITLE
PATH implementation

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,6 +47,7 @@ impl Runnable {
     }
 
     // Constructs an External Runnable from a path
+    // ? Do validation checks here?
     fn external(path: PathBuf) -> Self {
         Self::External(path)
     }
@@ -245,7 +246,14 @@ impl CommandManager {
             return Some(command.runnable.run(context, command_args));
         } else {
             // ? Should the path be canonicalized in the Runnable::External constructor or here?
-            let path = path::resolve(command_name, context.home());
+            let mut path = path::resolve_executable(command_name, context.env().path());
+            // If the executable is not found within any of the PATH directories,
+            // try to find it by canonicalizing the provided path to executable/command name
+            // ! This will need to moved to a 'run' builtin
+            if let None = path {
+                path = path::resolve(command_name, context.home());
+            }
+
             if let Some(path) = path {
                 // ? Should we check if the file is an executable first?
                 let runnable = Runnable::external(path);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -14,6 +14,9 @@ pub struct Environment {
     pub working_directory: Path,
     backward_directories: VecDeque<PathBuf>,
     forward_directories: VecDeque<PathBuf>,
+    // * 'path' is not to be confused with the 'working_directory.' 'path' is a list of directories which
+    // * the shell will search for executables in. 'Working_directory' is the current directory the user is in.
+    path: Vec<PathBuf>,
     custom_variables: HashMap<String, String>,
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -147,6 +147,20 @@ pub fn resolve(path: &str, home_directory: &PathBuf) -> Option<PathBuf> {
     }
 }
 
+// ! This is a temporary function whose functionality should potentially be shared with resolve()
+pub fn resolve_executable(name: &str, path: &Vec<PathBuf>) -> Option<PathBuf> {
+    for dir in path {
+        let mut path = dir.clone();
+        path.push(name);
+
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
 fn expand_home(path: &str, home_directory: &PathBuf) -> Result<String> {
     if path.starts_with("~") {
         Ok(path.replace(


### PR DESCRIPTION
The shell now has the ability to resolve executable in the PATH directories rather than only being able to use relative and absolute directory paths to canonicalize them. There is no way to modify the PATH variable in the shell yet.