### PR TITLE
Command refactor

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -243,7 +243,7 @@ pub fn run_executable(context: &mut Context, args: Vec<&str>) -> Result<()> {
         InternalCommandError::FailedToRun
     })?;
 
-    let executable = Runnable::external(executable_path);
+    let executable = Runnable::external(executable_path)?;
     executable.run(context, args)
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -136,7 +136,7 @@ pub struct Dispatcher {
 }
 
 impl Default for Dispatcher {
-    // Initializes the command manager with the default shell commands and aliases
+    // Initializes the Dispatcher with the default shell commands and aliases
     #[rustfmt::skip]
     fn default() -> Self {
         let mut dispatcher = Self::new();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -59,7 +59,7 @@ impl Shell {
         // Bundle all the information that needs to be modifiable by the commands into a Context
         let mut context = Context::new(self);
 
-        // Dispatch the command to the CommandManager
+        // Dispatch the command to the Dispatcher
         let exit_code = dispatcher.dispatch(command_name, command_args, &mut context);
 
         // If the command was not found, print an error message

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -3,7 +3,7 @@ use std::io::{stdin, stdout, Write};
 use anyhow::Result;
 use colored::Colorize;
 
-use crate::commands::{CommandManager, Context};
+use crate::commands::{Context, Dispatcher};
 use crate::environment::Environment;
 use crate::errors::ShellError;
 
@@ -23,7 +23,7 @@ impl Shell {
     // Repeatedly prompts the user for commands and executes them
     pub fn run(&mut self) -> Result<()> {
         // ? What should this name be?
-        let dispatcher = CommandManager::default();
+        let dispatcher = Dispatcher::default();
 
         loop {
             self.interpret(&dispatcher, self.prompt()?);
@@ -49,7 +49,7 @@ impl Shell {
     }
 
     // Interprets a command from a string
-    fn interpret(&mut self, dispatcher: &CommandManager, line: String) {
+    fn interpret(&mut self, dispatcher: &Dispatcher, line: String) {
         let mut words = line.split_whitespace();
         // Get the first word (the command name)
         let command_name = words.next().unwrap();


### PR DESCRIPTION
Major refactor of command handling. `Command` is now `Builtin`, `CommandManager` is now `Dispatcher`, and `Runnable::Internal` now contains a `Builtin`.