### PR TITLE
Path refactor

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum ShellError {
     FailedToReadStdin,
     #[error("Directory does not exist")]
     UnknownDirectory,
+    #[error("Executable could not be found in PATH")]
+    UnknownExecutable,
     #[error("Unknown error")]
     Uncategorized,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -29,12 +29,7 @@ impl Path {
     pub fn from_pathbuf(path: &PathBuf, home_directory: &PathBuf) -> Result<Self> {
         // The home directory shorthand must be expanded before resolving the path,
         // because PathBuf is not user-aware and only uses absolute and relative paths
-        // * This is kind of dumb as the path has usually been converted to a PathBuf from a string already,
-        // * but because of the way this constructor is supposed to work, it's just going to need to be converted right back again
-        let path_str = path
-            .to_str()
-            .ok_or(ShellError::FailedToConvertPathBufToString)?;
-        let expanded_path = expand_home(path_str, home_directory)?;
+        let expanded_path = expand_home(path, home_directory)?;
         // Canonicalizing a path will resolve any relative or absolute paths
         let absolute_path = canonicalize(expanded_path)?;
 
@@ -110,7 +105,8 @@ impl Path {
     }
 }
 
-fn expand_home(path: &str, home_directory: &PathBuf) -> Result<String> {
+fn expand_home(path: &PathBuf, home_directory: &PathBuf) -> Result<String> {
+    let path = path.to_str().ok_or(ShellError::FailedToConvertPathBufToString)?;
     if path.starts_with("~") {
         Ok(path.replace(
             "~",

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,7 +7,8 @@ use anyhow::Result;
 use crate::errors::ShellError;
 
 // Wrapper class for a directory path string
-// Adds convenience methods for displaying the path in a user-friendly way
+// Adds convenience methods for displaying the path in a user-friendly way,
+// and adds guarantees about path validity that are not provided by PathBuf
 #[derive(Clone)]
 pub struct Path {
     absolute_path: PathBuf,

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,11 +7,10 @@ use anyhow::Result;
 use crate::errors::ShellError;
 
 // Wrapper class for a directory path string
+// Adds convenience methods for displaying the path in a user-friendly way
+#[derive(Clone)]
 pub struct Path {
     absolute_path: PathBuf,
-    home_directory: PathBuf,
-    shortened_path: String,
-    truncation_factor: Option<usize>,
 }
 
 impl Display for Path {
@@ -21,57 +20,61 @@ impl Display for Path {
 }
 
 impl Path {
-    // Safely constructs a new Path from a given directory, taking into account
-    // the user's home directory so it can be collapsed into a shorthand '~'
-    pub fn new(absolute_path: PathBuf, home_directory: &PathBuf) -> Result<Self> {
-        let home_directory = home_directory.clone();
-        let mut path = Self {
-            absolute_path,
-            home_directory,
-            shortened_path: String::new(),
-            truncation_factor: None,
-        };
-
-        path.update_shortened_path()?;
-        Ok(path)
+    // Attempts to construct a new Path from a given path string by resolving it to an absolute path
+    pub fn from_str(path: &str, home_directory: &PathBuf) -> Result<Self> {
+        Self::from_pathbuf(&PathBuf::from(path), home_directory)
     }
 
-    // Attempts to construct a new Path from a given path string by resolving it to an absolute path
-    pub fn from_str_path(path: &str, home_directory: &PathBuf) -> Result<Self> {
-        match resolve(path, home_directory) {
-            Some(absolute_path) => Ok(Self::new(absolute_path, home_directory)?),
-            None => Err(ShellError::UnknownDirectory.into()),
+    // Attempts to construct a new Path from a given PathBuf by first resolving it to an absolute path
+    pub fn from_pathbuf(path: &PathBuf, home_directory: &PathBuf) -> Result<Self> {
+        // The home directory shorthand must be expanded before resolving the path,
+        // because PathBuf is not user-aware and only uses absolute and relative paths
+        // * This is kind of dumb as the path has usually been converted to a PathBuf from a string already,
+        // * but because of the way this constructor is supposed to work, it's just going to need to be converted right back again
+        let path_str = path
+            .to_str()
+            .ok_or(ShellError::FailedToConvertPathBufToString)?;
+        let expanded_path = expand_home(path_str, home_directory)?;
+        // Canonicalizing a path will resolve any relative or absolute paths
+        let absolute_path = canonicalize(expanded_path)?;
+
+        // If the file system can canonicalize the path, it should exist,
+        // but this is added for extra precaution
+        if !absolute_path.exists() {
+            Err(ShellError::UnknownDirectory.into())
+        } else {
+            Ok(Self { absolute_path })
         }
     }
 
+    // Attempts to construct a new Path from the PATH environment variable,
+    // given the name of an executable that is in the PATH
+    pub fn from_path_var(name: &str, path: &Vec<Path>) -> Result<Self> {
+        for dir in path {
+            let mut path = dir.path().clone();
+            path.push(name);
+
+            if path.exists() {
+                return Ok(Self {
+                    absolute_path: path,
+                });
+            }
+        }
+
+        Err(ShellError::UnknownExecutable.into())
+    }
+
     // Gets the absolute path, with all directory names included
-    pub fn absolute(&self) -> &PathBuf {
+    pub fn path(&self) -> &PathBuf {
         &self.absolute_path
     }
 
     // Gets the shortened version of the path
-    // If truncation is enabled, the path will be truncated
+    // If a truncation factor is provided, the path will be truncated
     // The shortened path will always have the home directory collapsed
-    pub fn short(&self) -> &String {
-        &self.shortened_path
-    }
-
-    // Sets the Path truncation factor
-    pub fn set_truncation(&mut self, factor: usize) -> Result<()> {
-        self.truncation_factor = Some(factor);
-        self.update_shortened_path()
-    }
-
-    // Disables Path truncation
-    pub fn disable_truncation(&mut self) -> Result<()> {
-        self.truncation_factor = None;
-        self.update_shortened_path()
-    }
-
-    // Re-generates the shortened path based on the current settings
-    fn update_shortened_path(&mut self) -> Result<()> {
+    pub fn collapse(&self, home_directory: &PathBuf, truncation_factor: Option<usize>) -> String {
         // ? Is there a less redundant way to write this?
-        let path = match self.absolute_path.strip_prefix(&self.home_directory) {
+        let path = match self.absolute_path.strip_prefix(home_directory) {
             Ok(path) => {
                 let mut path_string = path.to_string_lossy().to_string();
                 // ? Is this really necessary? Wouldn't it be fine to just have '~/'?
@@ -90,7 +93,7 @@ impl Path {
         let directories: Vec<String> = path.split("/").map(|d| d.to_string()).collect();
         let mut truncated_directories = Vec::new();
 
-        if let Some(factor) = self.truncation_factor {
+        if let Some(factor) = truncation_factor {
             for dir in directories {
                 let mut truncated_dir = dir.clone();
                 if dir.len() > factor {
@@ -103,50 +106,8 @@ impl Path {
             truncated_directories = directories;
         }
 
-        let truncated_directories = truncated_directories.join("/");
-        Ok(self.shortened_path = truncated_directories)
+        truncated_directories.join("/")
     }
-
-    // Updates the Path using a new absolute path
-    pub fn set_path(&mut self, new_path: &str) -> Result<()> {
-        // ? Should this be a FailedToCanonicalizePath error?
-        let new_absolute_path =
-            resolve(new_path, &self.home_directory).ok_or_else(|| ShellError::UnknownDirectory)?;
-        self.absolute_path = new_absolute_path;
-        self.update_shortened_path()
-    }
-}
-
-// Attempts to convert a path string into a canonicalized absolute path
-// ? Should this be a Result instead of an Option?
-pub fn resolve(path: &str, home_directory: &PathBuf) -> Option<PathBuf> {
-    // The home directory shorthand must be expanded before resolving the path,
-    // because PathBuf is not user-aware and only uses absolute and relative paths
-    let expanded_path = expand_home(path, home_directory).ok()?;
-    // Canonicalizing a path will resolve any relative or absolute paths
-    let absolute_path = canonicalize(expanded_path).ok()?;
-
-    // If the file system can canonicalize the path, it should exist,
-    // but this is added for extra precaution
-    if !absolute_path.exists() {
-        None
-    } else {
-        Some(absolute_path)
-    }
-}
-
-// ! This is a temporary function whose functionality should potentially be shared with resolve()
-pub fn resolve_executable(name: &str, path: &Vec<PathBuf>) -> Option<PathBuf> {
-    for dir in path {
-        let mut path = dir.clone();
-        path.push(name);
-
-        if path.exists() {
-            return Some(path);
-        }
-    }
-
-    None
 }
 
 fn expand_home(path: &str, home_directory: &PathBuf) -> Result<String> {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -22,7 +22,6 @@ impl Shell {
 
     // Repeatedly prompts the user for commands and executes them
     pub fn run(&mut self) -> Result<()> {
-        // ? What should this name be?
         let dispatcher = Dispatcher::default();
 
         loop {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -7,8 +7,11 @@ use crate::commands::{Context, Dispatcher};
 use crate::environment::Environment;
 use crate::errors::ShellError;
 
+// Represents the shell, its state, and provides methods for interacting with it
 pub struct Shell {
     pub environment: Environment,
+    // ! This is here temporarily, it will be moved to a Configuration struct soon
+    truncation_factor: Option<usize>,
     success: bool,
 }
 
@@ -16,6 +19,7 @@ impl Shell {
     pub fn new() -> Result<Self> {
         Ok(Self {
             environment: Environment::new()?,
+            truncation_factor: None,
             success: true,
         })
     }
@@ -33,10 +37,14 @@ impl Shell {
 
     // Displays the prompt and returns the user input
     fn prompt(&self) -> Result<String> {
+        let home = self.environment.home();
         print!(
             "{} on {}\n{} ",
             self.environment.user().blue(),
-            self.environment.working_directory.short().green(),
+            self.environment
+                .WORKING_DIRECTORY
+                .collapse(home, self.truncation_factor)
+                .green(),
             match self.success {
                 true => "❯".bright_green().bold(),
                 false => "❯".bright_red().bold(),
@@ -69,6 +77,16 @@ impl Shell {
                 self.success = false;
             }
         }
+    }
+
+    // Sets the truncation factor for the prompt
+    pub fn truncate(&mut self, factor: usize) {
+        self.truncation_factor = Some(factor);
+    }
+
+    // Disables prompt truncation
+    pub fn disable_truncation(&mut self) {
+        self.truncation_factor = None;
     }
 }
 


### PR DESCRIPTION
Greatly reduced the amount of finagling that needed to be done around management of paths by simplifying/enhancing the `Path` type from `path.rs` to be more of a simple wrapper around `PathBuf` than a convenient way to store the working directory & shorten it when printing the prompt.