### PR TITLE
Cleanup of the code, implemeting Write

### DIFF
--- a/rush-eval/src/dispatcher.rs
+++ b/rush-eval/src/dispatcher.rs
@@ -78,7 +78,7 @@ impl Dispatcher {
     }
 
     // Evaluates and executes a command from a string
-    pub fn eval(&self, shell: &mut Shell, console: &mut Console, line: &String) -> Result<()> {
+    pub fn eval(&self, shell: &mut Shell, console: &mut Console, line: &str) -> Result<()> {
         let commands = parser::parse(line);
         let mut results: Vec<Result<()>> = Vec::new();
 

--- a/rush-eval/src/parser.rs
+++ b/rush-eval/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::tokenizer::tokenize;
 use std::collections::VecDeque;
 
-pub fn parse(input: &String) -> Vec<(String, VecDeque<String>)> {
+pub fn parse(input: &str) -> Vec<(String, VecDeque<String>)> {
     let tokens_binding = tokenize(input);
     let mut tokens = tokens_binding.iter().peekable();
 
@@ -53,7 +53,7 @@ mod tests {
         assert_eq!(first_command_args, &String::from("-a"));
 
         assert_eq!(second_command, &String::from("ls"));
-        assert_eq!(second_command_args, true);
+        assert!(second_command_args);
     }
 
     #[test]

--- a/rush-exec/src/commands.rs
+++ b/rush-exec/src/commands.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::io::{BufRead, BufReader};
 use std::process::{Command as Process, Stdio};
 use std::sync::mpsc;
@@ -133,13 +134,13 @@ impl Runnable for Executable {
 
         while !stdout_done || !stderr_done || !process_done {
             if let Ok(line) = rx_stdout.recv_timeout(read_timeout) {
-                console.println(&line);
+                console.write_str(line.as_str()).unwrap();
             } else {
                 stdout_done = true;
             }
 
             if let Ok(line) = rx_stderr.recv_timeout(read_timeout) {
-                console.println(&line);
+                console.write_str(line.as_str()).unwrap();
             } else {
                 stderr_done = true;
             }

--- a/rush-state/src/console.rs
+++ b/rush-state/src/console.rs
@@ -292,6 +292,14 @@ impl<'a> Console<'a> {
     }
 }
 
+impl std::fmt::Write for Console<'_> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.print(s);
+
+        Ok(())
+    }
+}
+
 impl<'a> ConsoleData<'a> {
     fn new() -> Self {
         Self {

--- a/rush-state/src/console.rs
+++ b/rush-state/src/console.rs
@@ -280,20 +280,18 @@ impl<'a> Console<'a> {
     // Prints a line of text to the console
     // TODO: Probably make this a macro in the future, but for now just make it use &str or String
     // TODO: Make lazy execution version of this, or a lazy execution mode
-    //? This function should be now private because of the `std::fmt::Write` impl? to discuss.
-    pub fn println(&mut self, text: &str) {
-        self.data.append_str_newline(text);
-        _ = self.draw_frame(true)
-    }
-
     // Prints a line of text to the console without a newline
+    #[deprecated]
     pub fn print(&mut self, text: &str) {
         self.data.append_str(text);
+
         _ = self.draw_frame(true)
     }
 }
 
 impl std::fmt::Write for Console<'_> {
+
+    #[allow(unused_results, deprecated)]
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         self.print(s);
 
@@ -778,12 +776,6 @@ impl<'a> ConsoleData<'a> {
         self.output_buffer.extend(spans)
     }
 
-    // Appends a string to the next line of the output buffer
-    fn append_str_newline(&mut self, string: &str) {
-        self.append_str(string);
-        self.append_newline()
-    }
-
     // Appends a Spans to the output buffer
     #[allow(dead_code)]
     fn append_spans(&mut self, spans: Spans<'a>) {
@@ -794,11 +786,6 @@ impl<'a> ConsoleData<'a> {
     fn append_spans_newline(&mut self, spans: Spans<'a>) {
         // TODO: Come up with a better name for this or merge it with append_newline() somehow
         self.output_buffer.lines.extend([spans, Spans::default()]);
-    }
-
-    // Appends a newline to the output buffer
-    fn append_newline(&mut self) {
-        self.output_buffer.lines.push(Spans::default());
     }
 
     // Ensures that there is an empty line at the end of the output buffer

--- a/rush-state/src/console.rs
+++ b/rush-state/src/console.rs
@@ -280,6 +280,7 @@ impl<'a> Console<'a> {
     // Prints a line of text to the console
     // TODO: Probably make this a macro in the future, but for now just make it use &str or String
     // TODO: Make lazy execution version of this, or a lazy execution mode
+    //? This function should be now private because of the `std::fmt::Write` impl? to discuss.
     pub fn println(&mut self, text: &str) {
         self.data.append_str_newline(text);
         _ = self.draw_frame(true)

--- a/rush-state/src/errors.rs
+++ b/rush-state/src/errors.rs
@@ -28,7 +28,7 @@ pub enum ShellError {
 #[derive(Error, Debug)]
 pub enum PathError {
     #[error("Failed to convert PathBuf to String: {0}")]
-    FailedToConvertPathBufToString(PathBuf),
+    FailedPathBufConversion(PathBuf),
     #[error("Failed to canonicalize directory path: {0}")]
     FailedToCanonicalize(PathBuf),
     #[error("Failed to access directory path: {0}")]

--- a/rush-state/src/path.rs
+++ b/rush-state/src/path.rs
@@ -1,7 +1,7 @@
 use fs_err::canonicalize;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path as FsPath, PathBuf};
 
 use anyhow::Result;
 
@@ -109,17 +109,17 @@ impl Path {
 }
 
 // Expands the home directory shorthand in a path string
-fn expand_home(path: &PathBuf, home_directory: &PathBuf) -> Result<String> {
+fn expand_home(path: &FsPath, home_directory: &FsPath) -> Result<String> {
     let path = path
         .to_str()
-        .ok_or(PathError::FailedToConvertPathBufToString(path.clone()))?;
+        .ok_or(PathError::FailedPathBufConversion(path.to_path_buf()))?;
     if path.starts_with('~') {
         Ok(path.replace(
             '~',
             home_directory
                 .to_str()
-                .ok_or(PathError::FailedToConvertPathBufToString(
-                    home_directory.clone(),
+                .ok_or(PathError::FailedPathBufConversion(
+                    home_directory.to_path_buf(),
                 ))?,
         ))
     } else {

--- a/rush-state/src/path.rs
+++ b/rush-state/src/path.rs
@@ -28,7 +28,7 @@ impl Path {
     }
 
     // Attempts to construct a new Path from a given PathBuf by first resolving it to an absolute path
-    fn from_pathbuf(path: &PathBuf, home_directory: &PathBuf) -> Result<Self> {
+    fn from_pathbuf(path: &FsPath, home_directory: &FsPath) -> Result<Self> {
         // The home directory shorthand must be expanded before resolving the path,
         // because PathBuf is not user-aware and only uses absolute and relative paths
         let expanded_path = expand_home(path, home_directory)?;

--- a/rush/src/main.rs
+++ b/rush/src/main.rs
@@ -5,6 +5,8 @@ use rush_eval::errors::DispatchError;
 use rush_state::console::Console;
 use rush_state::shell::Shell;
 
+use std::fmt::Write;
+
 fn main() -> Result<()> {
     // The Shell type stores all of the state for the shell, including its configuration,
     // its environment, and other miscellaneous data like command history
@@ -34,12 +36,12 @@ fn handle_error(error: Result<()>, shell: &mut Shell, console: &mut Console) {
         Err(e) => {
             match e.downcast_ref::<DispatchError>() {
                 Some(DispatchError::UnknownCommand(command_name)) => {
-                    console.println(&format!("Unknown command: {}", command_name));
+                    writeln!(console, "Unknown command: {}", command_name).unwrap();
                 }
                 _ => {
                     if shell.config().show_errors {
                         // TODO: This is sort of a "magic" formatting string, it should be changed to a method or something
-                        console.println(&format!("Error: {:#?}: {}", e, e));
+                        writeln!(console, "Error: {0:#?}: {0}", e).unwrap();
                     }
                 }
             }


### PR DESCRIPTION
this pull request contains a second part of the refactor, and the implementation of `std::fmt::Write` for `Console`, to allow writing without necessary overhead.