### PR TITLE
Add show macro

### DIFF
--- a/rush-exec/src/builtins.rs
+++ b/rush-exec/src/builtins.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 
 use crate::builtin_arguments::ListDirectoryArguments;
 use rush_state::console::Console;
+use rush_state::showln;
 use rush_state::path::Path;
 use rush_state::shell::Shell;
 
@@ -305,7 +306,7 @@ fn check_args(
     if args.len() == expected_args {
         Ok(())
     } else {
-        console.println(&format!("Usage: {}", usage));
+        showln!(console, "Usage: {}", usage);
         Err(BuiltinError::InvalidArgumentCount(args.len()).into())
     }
 }

--- a/rush-state/src/console.rs
+++ b/rush-state/src/console.rs
@@ -295,7 +295,7 @@ impl<'a> Console<'a> {
 #[macro_export]
 macro_rules! show {
     ($console:expr, $($arg:tt)*) => {
-        $console.print(&format!($($arg)*))
+        $console.print(&::std::format!($($arg)*))
     };
 }
 
@@ -306,7 +306,7 @@ macro_rules! showln {
     };
 
     ($console:expr, $($arg:tt)*) => {
-        $console.println(&format!($($arg)*))
+        $console.println(&::std::format!($($arg)*))
     };
 }
 

--- a/rush-state/src/console.rs
+++ b/rush-state/src/console.rs
@@ -292,6 +292,24 @@ impl<'a> Console<'a> {
     }
 }
 
+#[macro_export]
+macro_rules! show {
+    ($console:expr, $($arg:tt)*) => {
+        $console.print(&format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! showln {
+    ($console:expr $(,)?) => {
+        $console.println("")
+    };
+
+    ($console:expr, $($arg:tt)*) => {
+        $console.println(&format!($($arg)*))
+    };
+}
+
 impl<'a> ConsoleData<'a> {
     fn new() -> Self {
         Self {


### PR DESCRIPTION
Something relatively basic to move discussion here without too much noise.

Declarative macros have a number of limitations, including:
- `#[macro_export]` exposes it at the top-level, hence `use rush_state::showln` instead of `use rush_state::console::showln`
- They're sanitary, so we can't do the previously discussed implicit console with them.