### PR TITLE
Maturing Runnable trait impl for external Executable 

### DIFF
--- a/rush-exec/src/builtins.rs
+++ b/rush-exec/src/builtins.rs
@@ -17,9 +17,9 @@ use anyhow::Result;
 
 use crate::builtin_arguments::ListDirectoryArguments;
 use rush_state::console::Console;
-use rush_state::showln;
 use rush_state::path::Path;
 use rush_state::shell::Shell;
+use rush_state::showln;
 
 use crate::commands::{Executable, Runnable};
 use crate::errors::BuiltinError;
@@ -196,7 +196,8 @@ pub fn read_file(_shell: &mut Shell, console: &mut Console, args: Vec<&str>) -> 
 pub fn run_executable(shell: &mut Shell, console: &mut Console, mut args: Vec<&str>) -> Result<()> {
     let executable_name = args[0].to_string();
     let executable_path = Path::from_str(&executable_name, shell.env().HOME()).map_err(|_| {
-        showln!(console, 
+        showln!(
+            console,
             "Failed to resolve executable path: '{}'",
             executable_name
         );

--- a/rush-exec/src/commands.rs
+++ b/rush-exec/src/commands.rs
@@ -106,7 +106,6 @@ impl Runnable for Executable {
         // Spawn a thread to read stdout
         let stdout_thread = {
             let stdout = process.stdout.take().unwrap();
-            let tx_stdout = tx_stdout.clone();
             thread::spawn(move || {
                 let reader = BufReader::new(stdout);
                 for line in reader.lines() {
@@ -130,7 +129,6 @@ impl Runnable for Executable {
 
         let stderr_thread = {
             let stderr = process.stderr.take().unwrap();
-            let tx_stderr = tx_stderr.clone();
             thread::spawn(move || {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines() {

--- a/rush-exec/src/commands.rs
+++ b/rush-exec/src/commands.rs
@@ -1,6 +1,6 @@
 use std::io::{BufRead, BufReader};
 use std::process::{Command as Process, Stdio};
-use std::sync::mpsc::{self, Sender, Receiver};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
@@ -162,14 +162,18 @@ impl Runnable for Executable {
                 if let Ok(line) = packet {
                     showln!(console, "{}", &line);
                 // If the packet is Err, propagate err up the stack
-                } else { packet?; }
+                } else {
+                    packet?;
+                }
             } else {
                 stdout_done = true;
             }
             if let Ok(packet) = rx_stderr.recv_timeout(read_timeout) {
                 if let Ok(line) = packet {
                     showln!(console, "{}", &line);
-                } else { packet?; }
+                } else {
+                    packet?;
+                }
             } else {
                 stderr_done = true;
             }

--- a/rush-exec/src/commands.rs
+++ b/rush-exec/src/commands.rs
@@ -100,8 +100,8 @@ impl Runnable for Executable {
         };
 
         // Create channels for communication between threads
-        let (tx_stdout, rx_stdout) = mpsc::channel::<Result<String, ExecutableError>>();
-        let (tx_stderr, rx_stderr) = mpsc::channel::<Result<String, ExecutableError>>();
+        let (tx_stdout, rx_stdout) = mpsc::channel::<Result<String>>();
+        let (tx_stderr, rx_stderr) = mpsc::channel::<Result<String>>();
 
         // Spawn a thread to read stdout
         let stdout_thread = {

--- a/rush-exec/src/errors.rs
+++ b/rush-exec/src/errors.rs
@@ -29,4 +29,8 @@ pub enum ExecutableError {
     PathNoLongerExists(PathBuf),
     #[error("Executable failed with exit code: {0}")]
     FailedToExecute(isize),
+    #[error("Failed to parse executable stdout: {0}")]
+    FailedToParseStdout(String),
+    #[error("Failed to parse executable stderr: {0}")]
+    FailedToParseStderr(String)
 }

--- a/rush-exec/src/errors.rs
+++ b/rush-exec/src/errors.rs
@@ -32,5 +32,5 @@ pub enum ExecutableError {
     #[error("Failed to parse executable stdout: {0}")]
     FailedToParseStdout(String),
     #[error("Failed to parse executable stderr: {0}")]
-    FailedToParseStderr(String)
+    FailedToParseStderr(String),
 }


### PR DESCRIPTION
Hi,

This pull request is to mature the Runnable trait impl for external binaries. Removed some of the unwraps for parsing lines and thread comms. There are still some unwraps to be dealt with but wanted to get out in front.

## Changes
- Added custom error types for parsing standard error and standard output streams from executables
- Added catch blocks to spawned threads and mapped errors to custom error types
- Unpacked streams and propagated errors up the stack (wasn't entirely sure of best way to deal with them, let me know if you'd rather some other approach.)

## Checklist
- [x] Code is formatted correctly using `cargo fmt`
- [x] Code has been linted using `cargo clippy` and all issues have been resolved